### PR TITLE
feat(forms): Add form-sections components structure

### DIFF
--- a/frontend/src/components/form-sections/ElectricalSection.tsx
+++ b/frontend/src/components/form-sections/ElectricalSection.tsx
@@ -1,0 +1,307 @@
+// frontend/src/components/form-sections/ElectricalSection.tsx
+
+import React from 'react';
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { ElectricalSectionProps } from './FormSectionTypes';
+
+const SERVICE_SIZES = ['100', '150', '200', '300', '400'];
+const VOLTAGE_OPTIONS = [
+  { value: '120-240', label: '120/240V' },
+  { value: '120-208', label: '120/208V' },
+  { value: '277-480', label: '277/480V' }
+];
+
+const ElectricalSection: React.FC<ElectricalSectionProps> = ({ 
+  formData = {}, 
+  updateFormData, 
+  toggleCheckbox, 
+  setRadioValue, 
+  toggleCheckboxOption 
+}) => {
+  // Create a wrapper handler to ensure data is structured correctly
+  const handleChange = (field: string, value: any) => {
+    console.log('ElectricalSection handleChange:', field, value);
+    // Use updateFormData directly with the field and value
+    updateFormData(field, value);
+  };
+
+  const handleGeneratorChange = (field: string, value: any) => {
+    const generator = {
+      ...(formData.generator || {}),
+      [field]: value
+    };
+    handleChange('generator', generator);
+  };
+
+  // Fallback handlers in case the props aren't passed
+  const handleRadioClick = (fieldId: string, value: string) => {
+    if (setRadioValue) {
+      setRadioValue(fieldId, value);
+    } else {
+      updateFormData(fieldId, value);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Service Details */}
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <div className="text-lg font-semibold">Electrical Service Details</div>
+
+          {/* Service Entry Type */}
+          <div className="space-y-2">
+            <Label>Service Entry Type</Label>
+            <div className="space-y-2">
+              {[
+                { value: 'overhead', label: 'Overhead' },
+                { value: 'underground', label: 'Underground' }
+              ].map((option) => {
+                const isSelected = formData.serviceType === option.value;
+                
+                return (
+                  <div 
+                    key={option.value} 
+                    className="flex items-center space-x-2 cursor-pointer"
+                    onClick={() => handleRadioClick('serviceType', option.value)}
+                  >
+                    {/* Custom radio visual */}
+                    <div className={`w-4 h-4 rounded-full border flex items-center justify-center ${isSelected ? 'border-blue-600 bg-blue-50' : 'border-gray-300'}`}>
+                      {isSelected && <div className="w-2 h-2 rounded-full bg-blue-600"></div>}
+                    </div>
+                    
+                    {/* Label */}
+                    <span className="text-sm">{option.label}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Phase Selection */}
+          <div className="space-y-2">
+            <Label>Phase Type</Label>
+            <div className="space-y-2">
+              {[
+                { value: 'single', label: 'Single Phase' },
+                { value: 'three', label: 'Three Phase' }
+              ].map((option) => {
+                const isSelected = formData.phaseType === option.value;
+                
+                return (
+                  <div 
+                    key={option.value} 
+                    className="flex items-center space-x-2 cursor-pointer"
+                    onClick={() => handleRadioClick('phaseType', option.value)}
+                  >
+                    {/* Custom radio visual */}
+                    <div className={`w-4 h-4 rounded-full border flex items-center justify-center ${isSelected ? 'border-blue-600 bg-blue-50' : 'border-gray-300'}`}>
+                      {isSelected && <div className="w-2 h-2 rounded-full bg-blue-600"></div>}
+                    </div>
+                    
+                    {/* Label */}
+                    <span className="text-sm">{option.label}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Voltage Selection */}
+          <div>
+            <Label htmlFor="voltage">System Voltage</Label>
+            <Select 
+              value={formData.voltage || ''} 
+              onValueChange={(value) => handleChange('voltage', value)}
+            >
+              <SelectTrigger className="mt-2">
+                <SelectValue placeholder="Select system voltage" />
+              </SelectTrigger>
+              <SelectContent>
+                {VOLTAGE_OPTIONS.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Service Size */}
+          <div>
+            <Label htmlFor="serviceSize">Service Size</Label>
+            <Select 
+              value={formData.serviceSize || ''} 
+              onValueChange={(value) => handleChange('serviceSize', value)}
+            >
+              <SelectTrigger className="mt-2">
+                <SelectValue placeholder="Select service size" />
+              </SelectTrigger>
+              <SelectContent>
+                {SERVICE_SIZES.map(size => (
+                  <SelectItem key={size} value={size}>
+                    {size} Amp
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Meter Location */}
+          <div>
+            <Label htmlFor="meterLocation">Meter Location</Label>
+            <Input
+              id="meterLocation"
+              value={formData.meterLocation || ''}
+              onChange={(e) => handleChange('meterLocation', e.target.value)}
+              placeholder="Specify meter location"
+              className="mt-2"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Panel Location */}
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <div className="text-lg font-semibold">Electrical Panel</div>
+          
+          <div>
+            <Label htmlFor="panelLocation">Panel Location (requires 18" width, 3' front clearance)</Label>
+            <Input
+              id="panelLocation"
+              value={formData.panelLocation || ''}
+              onChange={(e) => handleChange('panelLocation', e.target.value)}
+              placeholder="Specify panel location"
+              className="mt-2"
+            />
+            <p className="text-sm text-gray-500 mt-1">
+              Note: Cannot be located in bathrooms or coat closets
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Generator */}
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="text-lg font-semibold">Whole House Generator</div>
+            <Switch
+              id="hasGenerator"
+              checked={formData.hasGenerator || false}
+              onCheckedChange={(checked) => handleChange('hasGenerator', checked)}
+            />
+          </div>
+
+          {formData.hasGenerator && (
+            <div className="space-y-4">
+              <div>
+                <Label htmlFor="generator-location">Generator Location</Label>
+                <Input
+                  id="generator-location"
+                  value={formData.generator?.location || ''}
+                  onChange={(e) => handleGeneratorChange('location', e.target.value)}
+                  placeholder="Specify generator location"
+                  className="mt-2"
+                />
+              </div>
+              
+              <div>
+                <Label htmlFor="generator-size">Generator Size (kW)</Label>
+                <Input
+                  id="generator-size"
+                  type="number"
+                  value={formData.generator?.size || ''}
+                  onChange={(e) => handleGeneratorChange('size', e.target.value)}
+                  placeholder="Enter size in kW"
+                  className="mt-2"
+                />
+              </div>
+
+              <div>
+                <Label htmlFor="generator-manufacturer">Manufacturer</Label>
+                <Input
+                  id="generator-manufacturer"
+                  value={formData.generator?.manufacturer || ''}
+                  onChange={(e) => handleGeneratorChange('manufacturer', e.target.value)}
+                  placeholder="Enter manufacturer name"
+                  className="mt-2"
+                />
+              </div>
+
+              <div>
+                <Label htmlFor="generator-model">Model Number</Label>
+                <Input
+                  id="generator-model"
+                  value={formData.generator?.model || ''}
+                  onChange={(e) => handleGeneratorChange('model', e.target.value)}
+                  placeholder="Enter model number"
+                  className="mt-2"
+                />
+              </div>
+
+              <div>
+                <Label htmlFor="generator-transfer-switch">Transfer Switch Model</Label>
+                <Input
+                  id="generator-transfer-switch"
+                  value={formData.generator?.transferSwitch || ''}
+                  onChange={(e) => handleGeneratorChange('transferSwitch', e.target.value)}
+                  placeholder="Enter transfer switch model"
+                  className="mt-2"
+                />
+              </div>
+
+              <div>
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    id="needs-spec-sheet"
+                    checked={formData.generator?.needsSpecSheet || false}
+                    onCheckedChange={(checked) => handleGeneratorChange('needsSpecSheet', checked)}
+                  />
+                  <Label htmlFor="needs-spec-sheet">Spec Sheet Required</Label>
+                </div>
+
+                {formData.generator?.needsSpecSheet && (
+                  <div className="mt-2 space-y-2">
+                    <Label>Spec Sheet Status</Label>
+                    <div className="space-y-2">
+                      {[
+                        { value: 'needed', label: 'Still Needed' },
+                        { value: 'received', label: 'Already Received' }
+                      ].map((option) => {
+                        const isSelected = formData.generator?.specSheetStatus === option.value;
+                        
+                        return (
+                          <div 
+                            key={option.value} 
+                            className="flex items-center space-x-2 cursor-pointer"
+                            onClick={() => handleGeneratorChange('specSheetStatus', option.value)}
+                          >
+                            {/* Custom radio visual */}
+                            <div className={`w-4 h-4 rounded-full border flex items-center justify-center ${isSelected ? 'border-blue-600 bg-blue-50' : 'border-gray-300'}`}>
+                              {isSelected && <div className="w-2 h-2 rounded-full bg-blue-600"></div>}
+                            </div>
+                            
+                            {/* Label */}
+                            <span className="text-sm">{option.label}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ElectricalSection;

--- a/frontend/src/components/form-sections/FormSectionTypes.ts
+++ b/frontend/src/components/form-sections/FormSectionTypes.ts
@@ -1,0 +1,97 @@
+// frontend/src/components/form-sections/FormSectionTypes.ts
+
+/**
+ * Base interface for all form section props
+ */
+export interface FormSectionProps {
+  formData: Record<string, any>;
+  updateFormData: (field: string, value: any) => void;
+  toggleCheckbox?: (field: string) => void;
+  setRadioValue?: (field: string, value: string) => void;
+  toggleCheckboxOption?: (field: string, option: string) => void;
+}
+
+/**
+ * Interface for specific electrical form data
+ */
+export interface ElectricalFormData {
+  serviceType?: string;
+  phaseType?: string;
+  voltage?: string;
+  serviceSize?: string;
+  meterLocation?: string;
+  panelLocation?: string;
+  hasGenerator?: boolean;
+  generator?: {
+    location?: string;
+    size?: string;
+    manufacturer?: string;
+    model?: string;
+    transferSwitch?: string;
+    needsSpecSheet?: boolean;
+    specSheetStatus?: string;
+  };
+}
+
+/**
+ * Interface for electrical section props
+ */
+export interface ElectricalSectionProps extends FormSectionProps {
+  formData?: ElectricalFormData;
+}
+
+/**
+ * Interface for bathroom form data
+ */
+export interface BathroomFormData {
+  toilets?: {
+    type?: string;
+    model?: string;
+    color?: string;
+    height?: string;
+    seatType?: string;
+  }[];
+  vanities?: {
+    style?: string;
+    width?: string;
+    sinkType?: string;
+    material?: string;
+    color?: string;
+  }[];
+  showers?: {
+    type?: string;
+    material?: string;
+    doorType?: string;
+    fixtureBrand?: string;
+    fixtureFinish?: string;
+  }[];
+  bathtubs?: {
+    type?: string;
+    material?: string;
+    jets?: boolean;
+    size?: string;
+  }[];
+  accessories?: string[];
+  floorTile?: {
+    material?: string;
+    size?: string;
+    color?: string;
+    pattern?: string;
+  };
+  wallTile?: {
+    material?: string;
+    size?: string;
+    color?: string;
+    pattern?: string;
+    height?: string;
+  };
+}
+
+/**
+ * Interface for bathroom section props
+ */
+export interface BathroomSectionProps extends FormSectionProps {
+  formData?: BathroomFormData;
+}
+
+// Add additional interfaces for other form sections as needed

--- a/frontend/src/components/form-sections/README.md
+++ b/frontend/src/components/form-sections/README.md
@@ -1,5 +1,67 @@
 # Form Sections
 
-This directory will contain all the form sections from the original pre-construction-checklist project. These will be migrated as-is to preserve the existing form structure and questions.
+This directory contains reusable form section components used in the pre-construction checklist and other forms throughout the Clear-Desk system.
 
-These components will be organized by section and integrated into the larger Clear-Desk system.
+## Component Structure
+
+Each form section follows a consistent pattern:
+
+- Uses TypeScript and React
+- Imports UI components from the shadcn/ui library
+- Accepts standardized props for form data and event handlers
+- Exports a typed interface for the form data specific to that section
+
+## Usage
+
+Import the form sections into your forms like this:
+
+```tsx
+import { ElectricalSection } from '@/components/form-sections';
+import { useState } from 'react';
+
+const MyForm = () => {
+  const [formData, setFormData] = useState({});
+  
+  const updateFormData = (field, value) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value
+    }));
+  };
+  
+  return (
+    <div>
+      <h1>My Form</h1>
+      <ElectricalSection 
+        formData={formData} 
+        updateFormData={updateFormData} 
+      />
+      {/* Add more sections as needed */}
+    </div>
+  );
+};
+```
+
+## Available Sections
+
+The following form sections are available:
+
+- `ElectricalSection`: For capturing electrical service details, panel information, and generator specifications
+- More sections to be added...
+
+## Form Section Interfaces
+
+Each form section has a corresponding TypeScript interface that describes the data structure that section manages. These are exported from the `FormSectionTypes.ts` file:
+
+```tsx
+import { ElectricalFormData, ElectricalSectionProps } from '@/components/form-sections';
+```
+
+## Adding New Sections
+
+When adding new form sections, follow this pattern:
+
+1. Create a new TypeScript file for the section (e.g., `PlumbingSection.tsx`)
+2. Add the corresponding interface to `FormSectionTypes.ts`
+3. Export the component in the `index.ts` file
+4. Document the new section in this README

--- a/frontend/src/components/form-sections/index.ts
+++ b/frontend/src/components/form-sections/index.ts
@@ -1,0 +1,11 @@
+// frontend/src/components/form-sections/index.ts
+
+import ElectricalSection from './ElectricalSection';
+
+// Export form sections
+export {
+  ElectricalSection
+};
+
+// Re-export types
+export * from './FormSectionTypes';

--- a/scripts/convert-form-section.md
+++ b/scripts/convert-form-section.md
@@ -1,0 +1,110 @@
+# Form Section Conversion Guide
+
+This document outlines the process for converting form sections from the `pre-construction-checklist` repository to the `clear-desk` repository.
+
+## Conversion Steps
+
+1. **Create Type Interfaces**
+   - For each form section, define a corresponding interface in `FormSectionTypes.ts`
+   - Follow the naming pattern: `{SectionName}FormData` and `{SectionName}SectionProps`
+
+2. **Copy and Convert Component**
+   - Copy the component from pre-construction-checklist repo
+   - Change file extension from `.jsx` to `.tsx`
+   - Add type annotations to function parameters and state
+   - Update import paths if necessary
+   - Import the appropriate interfaces from `FormSectionTypes.ts`
+
+3. **Update Component Exports**
+   - Add the new component to the exports in `index.ts`
+
+4. **Update README.md**
+   - Document the new form section in the README
+
+## Example Conversion Process
+
+### Original JSX Component (pre-construction-checklist repo)
+
+```jsx
+import React from 'react';
+import { Card, CardContent } from "@/components/ui/card";
+
+const SampleSection = ({ formData = {}, updateFormData }) => {
+  const handleChange = (field, value) => {
+    updateFormData(field, value);
+  };
+  
+  return (
+    <Card>
+      <CardContent>
+        {/* Component content */}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SampleSection;
+```
+
+### Converted TSX Component (clear-desk repo)
+
+```tsx
+import React from 'react';
+import { Card, CardContent } from "@/components/ui/card";
+import { SampleSectionProps } from './FormSectionTypes';
+
+const SampleSection: React.FC<SampleSectionProps> = ({ 
+  formData = {}, 
+  updateFormData 
+}) => {
+  const handleChange = (field: string, value: any) => {
+    updateFormData(field, value);
+  };
+  
+  return (
+    <Card>
+      <CardContent>
+        {/* Component content */}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SampleSection;
+```
+
+### Type Definitions in FormSectionTypes.ts
+
+```tsx
+export interface SampleFormData {
+  field1?: string;
+  field2?: boolean;
+  // Add all fields used in the component
+}
+
+export interface SampleSectionProps extends FormSectionProps {
+  formData?: SampleFormData;
+}
+```
+
+### Update index.ts
+
+```tsx
+import ElectricalSection from './ElectricalSection';
+import SampleSection from './SampleSection';
+
+export {
+  ElectricalSection,
+  SampleSection
+};
+
+export * from './FormSectionTypes';
+```
+
+## Tips for Conversion
+
+- Keep the same field names and structure to maintain compatibility with existing data
+- Use optional chaining (`?.`) for nested properties that might be undefined
+- Use default values (e.g., `|| ''`, `|| false`) to handle undefined values
+- Remove `console.log` statements unless needed for debugging
+- Add JSDoc comments to document complex functionality


### PR DESCRIPTION
This PR adds the initial structure for form-sections components, transferred from the pre-construction-checklist repository.

## Changes

- Created TypeScript interfaces for form section props in `FormSectionTypes.ts`
- Converted `ElectricalSection` from JSX to TypeScript as a first example
- Added index.ts file to export components
- Added README.md with documentation and usage examples
- Added conversion guide in scripts directory

## Next Steps

After this PR is merged, we will continue converting the remaining form sections from the pre-construction-checklist repository:
- AVSection
- ApprovalsSection
- BathroomSection
- CarpentrySection
- CustomerInfoSection
- And others...

The conversion process will follow the guidelines in the conversion guide.

## Testing

The converted `ElectricalSection` has been manually tested to ensure it:
- Accepts the same props structure as the original component
- Handles form data management correctly
- Maintains the same styling and functionality

Closes #1 (if applicable)
